### PR TITLE
Add nodeAffinity for when nodeSelector is not enough

### DIFF
--- a/charts/nvidia-installer/templates/ds-k8s-nvidia-deviceplugin.yaml
+++ b/charts/nvidia-installer/templates/ds-k8s-nvidia-deviceplugin.yaml
@@ -20,6 +20,11 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- if .Values.nvidiaDevicePlugin.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+{{  toYaml .Values.nvidiaDevicePlugin.nodeAffinity | indent 10 }}
+      {{- end}}
       priorityClassName: system-node-critical
       volumes:
       - name: device-plugin

--- a/charts/nvidia-installer/templates/ds-k8s-nvidia-driver.yaml
+++ b/charts/nvidia-installer/templates/ds-k8s-nvidia-driver.yaml
@@ -18,6 +18,11 @@ spec:
         name: {{ template "nvidia-installer.name" . }}
         k8s-app: {{ template "nvidia-installer.name" . }}
     spec:
+      {{- if .Values.nvidiaInstaller.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+{{ toYaml .Values.nvidiaInstaller.nodeAffinity | indent 10 }}
+      {{- end}}
       hostPID: true
       initContainers:
       - image: {{ printf "%s:%s" .Values.nvidiaInstaller.image .Values.nvidiaInstaller.tag }}

--- a/charts/nvidia-installer/values.yaml
+++ b/charts/nvidia-installer/values.yaml
@@ -5,6 +5,14 @@ nvidiaInstaller:
   driverVersion: 396.18
   hostDriverPath: /opt/drivers
   nodeSelector: {}
+  nodeAffinity: {}
+  # Example:
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: gpu
+  #              operator: Exists
   tolerations:
    - key: "nvidia.com/gpu"
      operator: "Exists"
@@ -18,6 +26,7 @@ nvidiaDevicePlugin:
   pauseTag: 3.1
   hostDevicePluginPath: /var/lib/kubelet/device-plugins
   nodeSelector: {}
+  nodeAffinity: {}
   tolerations:
    - key: CriticalAddonsOnly
      operator: Exists


### PR DESCRIPTION
For example, when a `shoot.yaml` specifies GPU type as follows:
```
        - name: nodes-gpu
          machineType: p2.xlarge
          labels:
            gpu: nvidia-tesla-k80
          taints: 
          - key: nvidia.com/gpu
            value: present
            effect: NoSchedule

        - name: nodes-gpu-v100
          machineType: p3.2xlarge
          labels:
            gpu: nvidia-tesla-v100
          taints: 
          - key: nvidia.com/gpu
            value: present
            effect: NoSchedule
```

The `gpu` label could have values of `nvidia-tesla-k80` or `nvidia-tesla-v100`, so `nodeSelector` cannot be used, and we can use `nodeAffinity` instead to ensure that the daemonsets only run their pods on GPU nodes.