### PR TITLE
Update default driver version to 410.104

### DIFF
--- a/charts/nvidia-installer/templates/ds-k8s-nvidia-driver.yaml
+++ b/charts/nvidia-installer/templates/ds-k8s-nvidia-driver.yaml
@@ -44,6 +44,8 @@ spec:
           value: /opt/modulus/cache
         - name: MODULUS_LD_ROOT
           value: /root
+        - name: IGNORE_MISSING_MODULE_SYMVERS
+          value: "1"
         volumeMounts:
         - name: etc-coreos
           mountPath: /etc/coreos

--- a/charts/nvidia-installer/values.yaml
+++ b/charts/nvidia-installer/values.yaml
@@ -2,7 +2,7 @@ nvidiaInstaller:
   namespace: kube-system
   image: squat/modulus
   tag: 4a1799e7aa0143bcbb70d354bab3e419b1f54972
-  driverVersion: 396.18
+  driverVersion: 410.104
   hostDriverPath: /opt/drivers
   nodeSelector: {}
   nodeAffinity: {}


### PR DESCRIPTION
This upgrades CUDA from v9 to v10, which in turn allows TensorFlow 1.13
and higher (1.14 is current).

Environment variable IGNORE_MISSING_MODULE_SYMVERS is set in order to
avoid a compiler error with the updated driver version.