### PR TITLE
Increase resources for the device plugin to improve stability

### DIFF
--- a/charts/nvidia-installer/values.yaml
+++ b/charts/nvidia-installer/values.yaml
@@ -36,7 +36,7 @@ nvidiaDevicePlugin:
   resources:
     requests:
       cpu: 50m
-      memory: 10Mi
+      memory: 50Mi
     limits:
-      cpu: 50m
-      memory: 10Mi
+      cpu: 100m
+      memory: 100Mi


### PR DESCRIPTION
In some clusters we have observed that errors occur with the original resource specs.
This issue is resolved with the resources in the commit.